### PR TITLE
Fix cmake minimum version

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 cmake_policy(SET CMP0015 NEW) # link_directories() relative path support
 
 project (swimmer_riscv)


### PR DESCRIPTION
I tried to build with cmake 2.8 and 3.0, but the build was failed.

```
$ cmake --version
cmake version 2.8.12.2
$ cmake . -DCMAKE_BUILD_TYPE=Release
-- The C compiler identification is GNU 4.8.5
-- The CXX compiler identification is GNU 4.8.5
-- Check for working C compiler: /bin/cc
-- Check for working C compiler: /bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /bin/c++
-- Check for working CXX compiler: /bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Generate config.hpp ...
-- USE_PERF=OFF
-- Configuring done
CMake Error at CMakeLists.txt:70 (add_library):
  Cannot find source file:

    ../src/inst_category_riscv.cpp

  Tried extensions .c .C .c++ .cc .cpp .cxx .m .M .mm .h .hh .h++ .hm .hpp
  .hxx .in .txx
```

cmake 3.1 or later seems to be success.

```
$ ~/temp/cmake-3.1.0-Linux-x86_64/bin/cmake . -DCMAKE_BUILD_TYPE=Release
-- The C compiler identification is GNU 4.8.5
-- The CXX compiler identification is GNU 4.8.5
-- Check for working C compiler: /bin/cc
-- Check for working C compiler: /bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /bin/c++
-- Check for working CXX compiler: /bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Generate config.hpp ...
-- USE_PERF=OFF
-- Configuring done
-- Generating done
```

So I think `cmake_minimum_required` should be 3.1.